### PR TITLE
3.4.1 b1 Update metadata and rebuild for missing osx-arm64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: 40e263f912de5a81d891619032983557d62a3d85843f9a9f30b98baea0cd7b47
 
 build:
-  number: 0
+  number: 1
+  skip: True  # [py<36]
   entry_points:
     - py.test-benchmark = pytest_benchmark.cli:main
     - pytest-benchmark = pytest_benchmark.cli:main
@@ -18,26 +19,33 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - setuptools
   run:
-    - python >=3.6
+    - python
     - pytest >=3.8
     - py-cpuinfo
-    - statistics  # [py<34]
-    - pathlib2    # [py<34]
 
 test:
+  requires:
+    - pip
   imports:
     - pytest_benchmark
     - pytest_benchmark.storage
   commands:
+    - pip check
     - py.test-benchmark help
 
 about:
   home: https://github.com/ionelmc/pytest-benchmark
-  license: BSD 2-clause
+  license: BSD-2-Clause
+  license_family: BSD
+  license_url: https://github.com/ionelmc/pytest-benchmark/blob/master/LICENSE
+  license_file: LICENSE
   summary: "A py.test fixture for benchmarking code"
+  dev_url: https://github.com/ionelmc/pytest-benchmark
+  doc_url: https://pytest-benchmark.readthedocs.io/en/stable/
+  doc_source_url: https://pytest-benchmark.readthedocs.io/en/stable/_sources/index.rst.txt
 
 extra:
     recipe-maintainers:


### PR DESCRIPTION
pytest-benchmark is missing py37 and py310 on osx-arm64

Action:
- Increase build number
- Update metadata
- Add pip check
- Remove obsolete dependencies

https://github.com/ionelmc/pytest-benchmark/blob/master/setup.cfg
https://github.com/ionelmc/pytest-benchmark/blob/master/setup.py
https://github.com/ionelmc/pytest-benchmark/blob/master/LICENSE

concourse: https://concourse.build.corp.continuum.io/teams/main/pipelines/cbousseau_pytest-benchmark