### PR TITLE
Version 3.4.1 py12 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1
 
 build:
-  skip: true # [py>37]
+  skip: true # [py<37]
   entry_points:
     - py.test-benchmark = pytest_benchmark.cli:main
     - pytest-benchmark = pytest_benchmark.cli:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: A py.test fixture for benchmarking code
-  description: A ``pytest`` fixture for benchmarking code. It will group the tests into rounds that are calibrated to the chosen timer.
+  description: A pytest fixture for benchmarking code. It will group the tests into rounds that are calibrated to the chosen timer.
   dev_url: https://github.com/ionelmc/pytest-benchmark
   doc_url: https://pytest-benchmark.readthedocs.io
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     - py.test-benchmark = pytest_benchmark.cli:main
     - pytest-benchmark = pytest_benchmark.cli:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -43,7 +43,9 @@ about:
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: A py.test fixture for benchmarking code
+  summary: A pytest fixture for benchmarking code
+  description: |
+    A pytest fixture for benchmarking code. It will group the tests by the fixture name and will run them with different number of iterations. It will also group the tests by the fixture name and will run them with different number of iterations. It will also group the tests by the fixture name and will run them with different number of iterations. It will also group the tests by the fixture name and will run them with different number of iterations.
   dev_url: https://github.com/ionelmc/pytest-benchmark
   doc_url: https://pytest-benchmark.readthedocs.io
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   host:
     - python
-    - setuptools >=30.3.0"
+    - setuptools >=30.3.0
     - wheel
     - pip
     - py-cpuinfo

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,7 @@ source:
   sha256: 40e263f912de5a81d891619032983557d62a3d85843f9a9f30b98baea0cd7b47
 
 build:
-<<<<<<< Updated upstream
   skip: true # [py<37]
-=======
->>>>>>> Stashed changes
   entry_points:
     - py.test-benchmark = pytest_benchmark.cli:main
     - pytest-benchmark = pytest_benchmark.cli:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - setuptools >=30.3.0
     - wheel
     - pip
-    - py-cpuinfo
     - py
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytest-benchmark" %}
-{% set version = "4.0.0" %}
+{% set version = "3.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,23 +7,25 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pytest-benchmark-{{ version }}.tar.gz
-  sha256: fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1
+  sha256: 40e263f912de5a81d891619032983557d62a3d85843f9a9f30b98baea0cd7b47
 
 build:
+<<<<<<< Updated upstream
   skip: true # [py<37]
+=======
+>>>>>>> Stashed changes
   entry_points:
     - py.test-benchmark = pytest_benchmark.cli:main
     - pytest-benchmark = pytest_benchmark.cli:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  number: 2
+  number: 1
 
 requirements:
   host:
     - python
-    - setuptools >=30.3.0
+    - setuptools
     - wheel
     - pip
-    - py
   run:
     - python
     - pytest >=3.8
@@ -45,9 +47,8 @@ about:
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: A pytest fixture for benchmarking code
-  description: |
-    A pytest fixture for benchmarking code. It will group the tests by the fixture name and will run them with different number of iterations. It will also group the tests by the fixture name and will run them with different number of iterations. It will also group the tests by the fixture name and will run them with different number of iterations. It will also group the tests by the fixture name and will run them with different number of iterations.
+  summary: A py.test fixture for benchmarking code
+  description: A ``pytest`` fixture for benchmarking code. It will group the tests into rounds that are calibrated to the chosen timer.
   dev_url: https://github.com/ionelmc/pytest-benchmark
   doc_url: https://pytest-benchmark.readthedocs.io
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     - py.test-benchmark = pytest_benchmark.cli:main
     - pytest-benchmark = pytest_benchmark.cli:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  number: 1
+  number: 2
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1
 
 build:
+  skip: true # [py>37]
   entry_points:
     - py.test-benchmark = pytest_benchmark.cli:main
     - pytest-benchmark = pytest_benchmark.cli:main
@@ -19,9 +20,11 @@ build:
 requirements:
   host:
     - python
-    - setuptools
+    - setuptools >=30.3.0"
     - wheel
     - pip
+    - py-cpuinfo
+    - py
   run:
     - python
     - pytest >=3.8


### PR DESCRIPTION
pytest-benchmark 3.4.1 

**Destination channel:** defaults

### Links

- [PKG-4511](https://anaconda.atlassian.net/browse/PKG-4511) 
- [Upstream repository](https://github.com/ionelmc/pytest-benchmark)
- [Upstream changelog/diff](https://github.com/ionelmc/pytest-benchmark/releases/tag/v3.4.1)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/graphql-core-feedstock/pull/5

### Explanation of changes:
- rebuild of older version for requirements for graphql in later python versions


[PKG-4511]: https://anaconda.atlassian.net/browse/PKG-4511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ